### PR TITLE
Gradle license plugin to check and add license header in all .java files

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
 	id 'com.github.kt3k.coveralls' version '2.6.3'
+	id "com.github.hierynomus.license" version "0.14.0"
 }
 apply plugin: 'java'
 apply plugin: 'eclipse'
@@ -23,6 +24,28 @@ dependencies {
     
 	testCompile 'junit:junit:4.12'
 }
+
+license {
+	include "**/*.java"
+    header rootProject.file('utils/licenseHeader')
+    headerDefinitions {
+        custom_definition {
+          firstLine = "/*******************************************************************************"
+          endLine   = " *******************************************************************************/"
+          beforeEachLine = " * "
+          firstLineDetectionPattern = "/*"
+          lastLineDetectionPattern  = " *"
+          allowBlankLines = false
+          isMultiline = true
+        }
+    }
+    mapping {
+    	java='custom_definition'
+    }
+    strictCheck true
+}
+
+build.dependsOn licenseTest
 
 jacocoTestCoverageVerification {
 	dependsOn check

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ license {
     strictCheck true
 }
 
-build.dependsOn licenseTest
+check.dependsOn licenseTest
 
 jacocoTestCoverageVerification {
 	dependsOn check

--- a/utils/licenseHeader
+++ b/utils/licenseHeader
@@ -1,0 +1,12 @@
+JReliability is free software: you can redistribute it and/or modify it under
+the terms of the GNU Lesser General Public License as published by the Free
+Software Foundation, either version 3 of the License, or (at your option) any
+later version.
+
+JReliability is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with JReliability. If not, see http://www.gnu.org/licenses/.


### PR DESCRIPTION
Implementing the suggestion by @felixreimann.
The gradle license plugin is included with a custom header in the Opt4J style (separating the license with an *****... style comment) and the JReliability license.
- the task `license` is included in the build such that files without a proper license will result in a build fail
- the task `licenseFormat` automatically generates licenses for files