### PR TITLE
Removed unnecessary dependsOn statement

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,8 +45,6 @@ license {
     strictCheck true
 }
 
-check.dependsOn licenseTest
-
 jacocoTestCoverageVerification {
 	dependsOn check
 }


### PR DESCRIPTION
The license plugin automatically adds the licenseCheck to the check environment as documented here:
> Also it will add the licenseCheck task to the check lifecycle task dependencies, so that during a regular build any missing headers are flagged.
https://github.com/hierynomus/license-gradle-plugin

Unfortunately, it adds it to the build task and not "only" to the check. Thus, the dependsOn statement can be removed. Adding it solely to the check task may require to adapt the plugin which I think is not worth the effort. If you disagree, please comment on the issue.